### PR TITLE
Third strategy for parallelizing PajeNG.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 set(LIB_INSTALL_DIR lib${LIB_SUFFIX} CACHE PATH "Directory where libraries are installed (relative to CMAKE_INSTALL_PREFIX).")
 
+SET(CMAKE_CXX_FLAGS "-pthread -std=gnu++11")
+
 # The PajeNG (Qt4 version)
 SET(PAJE_HEADERS
   src/pajeng/PajeApplication.h
@@ -51,7 +53,8 @@ SET(LIBPAJE_HEADERS
   src/libpaje/PajeSimulator.h
   src/libpaje/PajeType.h
   src/libpaje/PajeValue.h
-  src/libpaje/PajeDefinitions.h)
+  src/libpaje/PajeDefinitions.h
+  src/libpaje/ThreadQueue.h)
 SET(LIBPAJE_SOURCES
   src/libpaje/PajeEventDefinition.cc
   src/libpaje/PajeTraceEvent.cc
@@ -71,6 +74,7 @@ SET(LIBPAJE_SOURCES
   src/libpaje/PajeColor.cc
   src/libpaje/PajeException.cc
   src/libpaje/PajeDefinitions.cc
+  src/libpaje/ThreadQueue.cc
 )
 
 # The Paje Utils Library (libpajeutils)

--- a/src/libpaje/PajeContainer.cc
+++ b/src/libpaje/PajeContainer.cc
@@ -37,6 +37,8 @@ PajeContainer::PajeContainer (double time, std::string name, std::string alias, 
 
 void PajeContainer::init (std::string alias, PajeContainer *parent)
 {
+  ThreadQueue *workerQueue = new ThreadQueue(); 
+  workerQueue->setQueue();  
   _alias = alias;
   _destroyed = false;
   if (parent){

--- a/src/libpaje/PajeContainer.h
+++ b/src/libpaje/PajeContainer.h
@@ -24,6 +24,7 @@
 #include "PajeTraceEvent.h"
 #include "PajeEvent.h"
 #include "PajeEntity.h"
+#include "ThreadQueue.h"
 
 class PajeContainer;
 class PajeEvent;
@@ -38,6 +39,7 @@ public:
   std::string _alias;
   std::map<std::string,PajeContainer*> children;
   int depth;
+  ThreadQueue workerQueue;
 
 private:
   std::map<PajeType*,std::set<std::string> > linksUsedKeys; //all used keys for this container

--- a/src/libpaje/PajeSimulator.cc
+++ b/src/libpaje/PajeSimulator.cc
@@ -34,7 +34,7 @@ PajeSimulator::PajeSimulator (double stopat)
 }
 
 PajeSimulator::PajeSimulator (double stopat, int ignore)
-{
+{ 
   stopSimulationAtTime = stopat;
   ignoreIncompleteLinks = ignore;
   init ();
@@ -389,7 +389,7 @@ void PajeSimulator::pajeCreateContainer (PajeTraceEvent *traceEvent)
   std::string containerid = traceEvent->valueForField (PAJE_Container);
   std::string name = traceEvent->valueForField (PAJE_Name);
   std::string alias = traceEvent->valueForField (PAJE_Alias);
-
+  
   //search the container type for the new container
   PajeType *type = typeMap[typestr];
   if (!type){
@@ -480,8 +480,8 @@ void PajeSimulator::pajeDestroyContainer (PajeTraceEvent *traceEvent)
   }
 
   //mark container as destroyed
-  PajeDestroyContainerEvent event (traceEvent, container, containerType);
-  container->demuxer (&event);
+  PajeDestroyContainerEvent *event = new PajeDestroyContainerEvent (traceEvent, container, containerType);
+  container->workerQueue.enqueue(event);
 }
 
 void PajeSimulator::pajeNewEvent (PajeTraceEvent *traceEvent)
@@ -535,8 +535,8 @@ void PajeSimulator::pajeNewEvent (PajeTraceEvent *traceEvent)
     val = type->addValue (value, value, NULL);
   }
 
-  PajeNewEventEvent event (traceEvent, container, type, val);
-  container->demuxer (&event);
+  PajeNewEventEvent *event = new PajeNewEventEvent (traceEvent, container, type, val);
+  container->workerQueue.enqueue(event);
 }
 
 void PajeSimulator::pajeSetState (PajeTraceEvent *traceEvent)
@@ -590,8 +590,8 @@ void PajeSimulator::pajeSetState (PajeTraceEvent *traceEvent)
     val = type->addValue (value, value, NULL);
   }
 
-  PajeSetStateEvent event (traceEvent, container, type, val);
-  container->demuxer (&event);
+  PajeSetStateEvent *event = new PajeSetStateEvent (traceEvent, container, type, val);
+  container->workerQueue.enqueue(event);
 }
 
 void PajeSimulator::pajePushState (PajeTraceEvent *traceEvent)
@@ -645,8 +645,8 @@ void PajeSimulator::pajePushState (PajeTraceEvent *traceEvent)
     val = type->addValue (value, value, NULL);
   }
 
-  PajePushStateEvent event (traceEvent, container, type, val);
-  container->demuxer (&event);
+  PajePushStateEvent *event = new PajePushStateEvent (traceEvent, container, type, val);
+  container->workerQueue.enqueue(event);
 }
 
 void PajeSimulator::pajePopState (PajeTraceEvent *traceEvent)
@@ -691,8 +691,8 @@ void PajeSimulator::pajePopState (PajeTraceEvent *traceEvent)
     throw PajeTypeException ("Type '"+ctype1.str()+"' is not child type of container type '"+ctype2.str()+"' in "+eventdesc.str());
   }
 
-  PajePopStateEvent event (traceEvent, container, type);
-  container->demuxer (&event);
+  PajePopStateEvent *event = new PajePopStateEvent (traceEvent, container, type);
+  container->workerQueue.enqueue(event);
 }
 
 
@@ -738,8 +738,8 @@ void PajeSimulator::pajeResetState (PajeTraceEvent *traceEvent)
     throw PajeTypeException ("Type '"+ctype1.str()+"' is not child type of container type '"+ctype2.str()+"' in "+eventdesc.str());
   }
 
-  PajeResetStateEvent event (traceEvent, container, type);
-  container->demuxer (&event);
+  PajeResetStateEvent *event = new PajeResetStateEvent (traceEvent, container, type);
+  container->workerQueue.enqueue(event);
 }
 
 void PajeSimulator::pajeSetVariable (PajeTraceEvent *traceEvent)
@@ -787,8 +787,8 @@ void PajeSimulator::pajeSetVariable (PajeTraceEvent *traceEvent)
 
   float v = strtof (value.c_str(), NULL);
 
-  PajeSetVariableEvent event (traceEvent, container, type, v);
-  container->demuxer (&event);
+  PajeSetVariableEvent *event = new PajeSetVariableEvent (traceEvent, container, type, v);
+  container->workerQueue.enqueue(event);
 }
 
 void PajeSimulator::pajeAddVariable (PajeTraceEvent *traceEvent)
@@ -835,8 +835,8 @@ void PajeSimulator::pajeAddVariable (PajeTraceEvent *traceEvent)
   }
 
   float v = strtof (value.c_str(), NULL);
-  PajeAddVariableEvent event (traceEvent, container, type, v);
-  container->demuxer (&event);
+  PajeAddVariableEvent *event = new PajeAddVariableEvent (traceEvent, container, type, v);
+  container->workerQueue.enqueue(event);
 }
 
 void PajeSimulator::pajeSubVariable (PajeTraceEvent *traceEvent)
@@ -884,8 +884,8 @@ void PajeSimulator::pajeSubVariable (PajeTraceEvent *traceEvent)
 
   float v = strtof (value.c_str(), NULL);
 
-  PajeSubVariableEvent event (traceEvent, container, type, v);
-  container->demuxer (&event);
+  PajeSubVariableEvent *event = new PajeSubVariableEvent (traceEvent, container, type, v);
+  container->workerQueue.enqueue(event);
 }
 
 void PajeSimulator::pajeStartLink (PajeTraceEvent *traceEvent)
@@ -960,8 +960,8 @@ void PajeSimulator::pajeStartLink (PajeTraceEvent *traceEvent)
     val = type->addValue (value, value, NULL);
   }
 
-  PajeStartLinkEvent event (traceEvent, container, type, val, startcontainer, key);
-  container->demuxer (&event);
+  PajeStartLinkEvent *event = new PajeStartLinkEvent (traceEvent, container, type, val, startcontainer, key);
+  container->workerQueue.enqueue(event);
 }
 
 void PajeSimulator::pajeEndLink (PajeTraceEvent *traceEvent)
@@ -1036,6 +1036,6 @@ void PajeSimulator::pajeEndLink (PajeTraceEvent *traceEvent)
     val = type->addValue (value, value, NULL);
   }
 
-  PajeEndLinkEvent event (traceEvent, container, type, val, endcontainer, key);
-  container->demuxer (&event);
+  PajeEndLinkEvent *event = new PajeEndLinkEvent (traceEvent, container, type, val, endcontainer, key);
+  container->workerQueue.enqueue(event);
 }

--- a/src/libpaje/ThreadQueue.cc
+++ b/src/libpaje/ThreadQueue.cc
@@ -1,0 +1,45 @@
+#include "ThreadQueue.h"
+
+ThreadQueue::ThreadQueue() :   stop(false){
+    return;
+}
+
+ThreadQueue::ThreadQueue(const ThreadQueue& orig) {
+}
+void ThreadQueue::setQueue(){
+        workers.emplace_back(
+            [this]
+            {
+                for(;;)
+                {
+                    std::unique_lock<std::mutex> lock(this->queue_mutex);
+                    while(!this->stop && this->tasks.empty())
+                        this->condition.wait(lock);
+                    
+                    if(this->stop && this->tasks.empty())
+                        return;
+                    
+                    PajeContainer *container = this->tasks.front()->container();
+                    container->demuxer(this->tasks.front());
+                    this->tasks.pop();
+                    lock.unlock();
+                }
+            }
+        );
+}
+void ThreadQueue::enqueue(PajeEvent *event) 
+{
+    std::unique_lock<std::mutex> lock(queue_mutex);
+    tasks.push(event);
+    condition.notify_one();
+}
+ThreadQueue::~ThreadQueue()
+{
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+        stop = true;
+    }
+    condition.notify_all();
+    for(size_t i = 0;i<workers.size();++i)
+        workers[i].join();
+}

--- a/src/libpaje/ThreadQueue.h
+++ b/src/libpaje/ThreadQueue.h
@@ -1,0 +1,29 @@
+#include <vector>
+#include <queue>
+#include <memory>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <functional>
+
+#include "PajeEvent.h"
+#include "PajeContainer.h"
+#ifndef THREADQUEUE_H
+#define	THREADQUEUE_H
+
+class ThreadQueue {
+public:
+    ThreadQueue();
+    ThreadQueue(const ThreadQueue& orig);
+    void enqueue(PajeEvent *event); 
+    void setQueue();
+     ~ThreadQueue();
+public:
+    std::vector< std::thread > workers;
+    std::queue<PajeEvent*> tasks;
+    std::mutex queue_mutex;
+    std::condition_variable condition;
+    bool stop;
+};
+
+#endif	/* THREADQUEUE_H */


### PR DESCRIPTION
This strategy creates a thread for each created container. This thread consume a queue of tasks provided by the simulator 
for this specific container.

Class ThreadQueue Included (ThreadQueue.h / ThreadQueue.cc).

Some modifications can be found in the PajeSimulator and PajeContainer where the ThreadQueue is instantiated.
