### PR TITLE
fix definition of argp parsing functions

### DIFF
--- a/src/tools/pj_dump.cc
+++ b/src/tools/pj_dump.cc
@@ -52,7 +52,7 @@ struct arguments {
   int userDefined;
 };
 
-static int parse_options (int key, char *arg, struct argp_state *state)
+static error_t parse_options (int key, char *arg, struct argp_state *state)
 {
   struct arguments *arguments = (struct arguments*)(state->input);
   switch (key){

--- a/src/tools/pj_validate.cc
+++ b/src/tools/pj_validate.cc
@@ -46,7 +46,7 @@ struct arguments {
   int flex;
 };
 
-static int parse_options (int key, char *arg, struct argp_state *state)
+static error_t parse_options (int key, char *arg, struct argp_state *state)
 {
   struct arguments *arguments = (struct arguments*)(state->input);
   switch (key){


### PR DESCRIPTION
The return value should be `error_t`, not simply `int` (even if usually `error_t` is a typedef for `int`).
