### PR TITLE
Fixed input size validation

### DIFF
--- a/src/tools/pj_dump.cc
+++ b/src/tools/pj_dump.cc
@@ -25,7 +25,7 @@
 
 extern int dumpFloatingPointPrecision;
 
-#define VALIDATE_INPUT_SIZE 2
+#define VALIDATE_INPUT_SIZE 1
 static char doc[] = "Dumps FILE, or standard input, in a CSV-like textual format";
 static char args_doc[] = "[FILE]";
 
@@ -80,7 +80,7 @@ static error_t parse_options (int key, char *arg, struct argp_state *state)
     arguments->input_size++;
     break;
   case ARGP_KEY_END:
-    if (state->arg_num < 0) {
+    if (state->arg_num < VALIDATE_INPUT_SIZE) {
       /* Not enough arguments. */
       argp_usage (state);
     }
@@ -168,7 +168,7 @@ int main (int argc, char **argv)
     delete unity;
     return 0;
   }
-  
+
   if (!arguments.quiet){
     dump (&arguments, unity);
   }

--- a/src/tools/pj_equals.cc
+++ b/src/tools/pj_equals.cc
@@ -21,7 +21,7 @@
 
 extern int dumpFloatingPointPrecision;
 
-#define VALIDATE_INPUT_SIZE 3
+#define VALIDATE_INPUT_SIZE 2
 static char doc[] = "Returns or prints to stdout 1 if two traces are equal, 0 otherwise.";
 static char args_doc[] = "FILE1 FILE2";
 
@@ -78,7 +78,7 @@ static error_t parse_options (int key, char *arg, struct argp_state *state)
     arguments->input_size++;
     break;
   case ARGP_KEY_END:
-    if (state->arg_num < 0) {
+    if (state->arg_num < VALIDATE_INPUT_SIZE) {
       /* Not enough arguments. */
       argp_usage (state);
     }

--- a/src/tools/pj_validate.cc
+++ b/src/tools/pj_validate.cc
@@ -22,7 +22,7 @@
 #include <argp.h>
 #include "libpaje_config.h"
 
-#define VALIDATE_INPUT_SIZE 2
+#define VALIDATE_INPUT_SIZE 1
 static char doc[] = "Checks if FILE, or standard input, strictly follows the Paje file format definition";
 static char args_doc[] = "[FILE]";
 
@@ -68,7 +68,7 @@ static error_t parse_options (int key, char *arg, struct argp_state *state)
     arguments->input_size++;
     break;
   case ARGP_KEY_END:
-    if (state->arg_num < 0) {
+    if (state->arg_num < VALIDATE_INPUT_SIZE) {
       /* Not enough arguments. */
       argp_usage (state);
     }


### PR DESCRIPTION
All tools would throw an exception/segfault with the wrong input size instead of displaying their usage. This commit fixes it.