### PR TITLE
fix FTBFS with Perl 5.26 [gregor herrmann]

### DIFF
--- a/tests/scripts/tesh
+++ b/tests/scripts/tesh
@@ -60,12 +60,12 @@ else{
 sub var_subst {
     my ($text, $name, $value) = @_;
     if ($value) {
-        $text =~ s/\${$name(?::[=-][^}]*)?}/$value/g;
+        $text =~ s/\$\{$name(?::[=-][^}]*)?}/$value/g;
         $text =~ s/\$$name(\W|$)/$value$1/g;
     }
     else {
-        $text =~ s/\${$name:=([^}]*)}/$1/g;
-        $text =~ s/\${$name}//g;
+        $text =~ s/\$\{$name:=([^}]*)}/$1/g;
+        $text =~ s/\$\{$name}//g;
         $text =~ s/\$$name(\W|$)/$1/g;
     }
     return $text;
@@ -232,7 +232,7 @@ sub exec_cmd {
       $cmd{'cmd'} = var_subst($cmd{'cmd'}, $key, $environ{$key});
   }
   # substitute remaining variables, if any
-  while ($cmd{'cmd'} =~ /\${(\w+)(?::[=-][^}]*)?}/) {
+  while ($cmd{'cmd'} =~ /\$\{(\w+)(?::[=-][^}]*)?}/) {
       $cmd{'cmd'} = var_subst($cmd{'cmd'}, $1, "");
   }
   while ($cmd{'cmd'} =~ /\$(\w+)/) {


### PR DESCRIPTION
Description: Fix "Unescaped left brace in regex is illegal here" errors with perl 5.26
Origin: Debian
Bug: https://github.com/schnorr/pajeng/issues/24
Bug-Debian: https://bugs.debian.org/870213
Author: gregor herrmann <gregoa@debian.org>
Last-Update: 2017-07-31

(fix #24)