### PR TITLE
Changed two-line install (docs)

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,7 +18,7 @@ ANR project]]. Development has continued through a collaboration between
 
 #+begin_src shell :results output :exports both
 sudo apt-get install git cmake build-essential libboost-dev asciidoc flex bison libfmt-dev;
-git clone git://github.com/schnorr/pajeng.git ; mkdir -p pajeng/b ; cd pajeng/b ; cmake -DCMAKE_BUILD_TYPE=Release .. ; make install
+git clone https://github.com/schnorr/pajeng.git ; mkdir -p pajeng/b ; cd pajeng/b ; cmake -DCMAKE_BUILD_TYPE=Release .. ; sudo make install
 #+end_src
 
 ** Spack Installation


### PR DESCRIPTION
"make install" requires sudo.
"git clone" now using https.